### PR TITLE
Fixed conditional in order to avoid empty tuple

### DIFF
--- a/irsa.tf
+++ b/irsa.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_admin" {
   create_role                   = var.eks ? true : false
   role_name                     = "velero.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [var.eks ? aws_iam_policy.velero.0.arn : "" ]
+  role_policy_arns              = [var.eks && length(aws_iam_policy.velero) >= 1 ? aws_iam_policy.velero.0.arn : "" ]
   oidc_fully_qualified_subjects = ["system:serviceaccount:velero:velero-server"]
 }
 


### PR DESCRIPTION
Otherwise, we face in EKS:

```
Error: Invalid index

  on .terraform/modules/velero/irsa.tf line 10, in module "iam_assumable_role_admin":
  10:   role_policy_arns              = [var.eks ? aws_iam_policy.velero.0.arn : "" ]
    |----------------
    | aws_iam_policy.velero is empty tuple

The given key does not identify an element in this collection value.
```

NOTE: This change only applies to EKS

