### PR TITLE
Upgrade Velero and added ImagePullSecrets

### DIFF
--- a/irsa.tf
+++ b/irsa.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_admin" {
   create_role                   = var.eks ? true : false
   role_name                     = "velero.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [var.eks && length(aws_iam_policy.velero) >= 1 ? aws_iam_policy.velero.0.arn : "" ]
+  role_policy_arns              = [var.eks && length(aws_iam_policy.velero) >= 1 ? aws_iam_policy.velero.0.arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:velero:velero-server"]
 }
 

--- a/kiam.tf
+++ b/kiam.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "velero_assume" {
 }
 
 resource "aws_iam_role" "velero" {
-  count = var.eks ? 0 : 1
+  count              = var.eks ? 0 : 1
   name               = "velero.${var.cluster_domain_name}"
   assume_role_policy = data.aws_iam_policy_document.velero_assume.json
 }
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "velero" {
     resources = ["*"]
   }
   statement {
-    actions = [ 
+    actions = [
       "s3:GetObject",
       "s3:DeleteObject",
       "s3:PutObject",
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "velero" {
 }
 
 resource "aws_iam_role_policy" "velero" {
-  count = var.eks ? 0 : 1
+  count  = var.eks ? 0 : 1
   name   = "velero"
   role   = aws_iam_role.velero.0.id
   policy = data.aws_iam_policy_document.velero.json

--- a/main.tf
+++ b/main.tf
@@ -29,14 +29,14 @@ resource "helm_release" "velero" {
   namespace  = kubernetes_namespace.velero.id
   repository = data.helm_repository.vmware_tanzu.metadata[0].name
   chart      = "velero"
-    version    = "2.9.15"
+  version    = "2.14.4"
 
   depends_on = [
     kubernetes_namespace.velero,
     var.dependence_prometheus,
   ]
   values = [templatefile("${path.module}/templates/velero.yaml.tpl", {
-    cluster_name = terraform.workspace
+    cluster_name        = terraform.workspace
     velero_iam_role     = var.eks ? "" : aws_iam_role.velero.0.name
     eks                 = var.eks
     eks_service_account = module.iam_assumable_role_admin.this_iam_role_arn
@@ -44,5 +44,28 @@ resource "helm_release" "velero" {
 
   lifecycle {
     ignore_changes = [keyring]
+  }
+}
+
+resource "kubernetes_secret" "dockerhub_credentials" {
+  count = var.eks ? 1 : 0
+
+  metadata {
+    name      = "dockerhub-credentials"
+    namespace = kubernetes_namespace.velero.id
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = <<DOCKER
+{
+  "auths": {
+    "https://index.docker.io/v1": {
+      "auth": "${base64encode("${var.dockerhub_username}:${var.dockerhub_password}")}"
+    }
+  }
+}
+DOCKER
   }
 }

--- a/templates/velero.yaml.tpl
+++ b/templates/velero.yaml.tpl
@@ -15,6 +15,9 @@ podAnnotations:
 %{ endif ~}
 
 %{ if eks ~}
+image:
+  imagePullSecrets:
+    - dockerhub-credentials 
 serviceAccount:
   server:
     create: true

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,15 @@ variable "cluster_domain_name" {
   description = "The cluster domain used for iam_assumable_role_admin role name"
 }
 
+variable "dockerhub_username" {
+  description = "Dockerhub password - used to pull images and avoid hitting dockerhub API limits"
+  default     = ""
+}
+
+variable "dockerhub_password" {
+  description = "Dockerhub password - used to pull images and avoid hitting dockerhub API limits"
+  default     = ""
+}
 
 # EKS variables
 variable "eks" {


### PR DESCRIPTION
In order to avoid hitting docker hub limits, we added `imagePullSecrets`. In order to do that we had to upgrade the Helm Chart to latest (our current version doesn't support it)