### PR TITLE
update-pin-helm-version-in-modules

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@v0.6.0
+      uses: terraform-docs/gh-actions@v0.11.0
       with:
         working-dir: .
         output-file: README.md

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,7 @@ terraform {
     }
     helm = {
       source = "hashicorp/helm"
+      version = "~> 2.6.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"


### PR DESCRIPTION
Update the module to pin helm version:
Why: 
[upgrade & pin Helm provider for Infrastructure#3882](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3882)