### PR TITLE
exclude storageclasses, some (EFS) are unsupported

### DIFF
--- a/templates/velero.yaml.tpl
+++ b/templates/velero.yaml.tpl
@@ -115,5 +115,7 @@ schedules:
     schedule: "0 0/3 * * *"
     template:
       ttl: "720h"
+    excludedResources:
+      - storageclasses.storage.k8s.io
 
 configMaps: {}


### PR DESCRIPTION
this will *not* skip PVs, but only the SC object definitions, which we create via terraform anyway