### PR TITLE
feat: 🎸 add tagging for backup aws resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Click [here](https://velero.io/docs/v1.2.0/) for the official Velero documentati
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_assumable_role_admin"></a> [iam\_assumable\_role\_admin](#module\_iam\_assumable\_role\_admin) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.52.2 |
+| <a name="module_iam_assumable_role_admin"></a> [iam\_assumable\_role\_admin](#module\_iam\_assumable\_role\_admin) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.55.0 |
 
 ## Resources
 

--- a/irsa.tf
+++ b/irsa.tf
@@ -40,6 +40,7 @@ data "aws_iam_policy_document" "velero_irsa" {
       "s3:PutObject",
       "s3:AbortMultipartUpload",
       "s3:ListMultipartUploadParts",
+      "s3:PutObjectTagging"
     ]
     resources = ["arn:aws:s3:::cloud-platform-velero-backups/*"]
   }

--- a/templates/velero.yaml.tpl
+++ b/templates/velero.yaml.tpl
@@ -74,7 +74,7 @@ configuration:
       # Tags that need to be placed on AWS S3 objects. 
       # For example "Key1=Value1&Key2=Value2"
       # Optional (defaults to empty "")
-      tagging: "business-unit=platforms&service-area=hosting"
+      tagging: "business-unit=Platforms&service-area=Hosting"
 
   backupSyncPeriod:
   # `velero server` default: 1h
@@ -118,8 +118,8 @@ nodeAgent:
 schedules:
   allnamespacebackup:
     labels:
-      business-unit: platforms
-      service-area: hosting
+      business-unit: Platforms
+      service-area: Hosting
     schedule: "0 0/3 * * *"
     template:
       ttl: "720h"

--- a/templates/velero.yaml.tpl
+++ b/templates/velero.yaml.tpl
@@ -74,7 +74,7 @@ configuration:
       # Tags that need to be placed on AWS S3 objects. 
       # For example "Key1=Value1&Key2=Value2"
       # Optional (defaults to empty "")
-      tagging: "business-unit=platforms"
+      tagging: "business-unit=platforms&service-area=hosting"
 
   backupSyncPeriod:
   # `velero server` default: 1h
@@ -119,6 +119,7 @@ schedules:
   allnamespacebackup:
     labels:
       business-unit: platforms
+      service-area: hosting
     schedule: "0 0/3 * * *"
     template:
       ttl: "720h"

--- a/templates/velero.yaml.tpl
+++ b/templates/velero.yaml.tpl
@@ -71,6 +71,10 @@ configuration:
     prefix: ${cluster_name}
     config:
       region: eu-west-2
+      # Tags that need to be placed on AWS S3 objects. 
+      # For example "Key1=Value1&Key2=Value2"
+      # Optional (defaults to empty "")
+      tagging: "business-unit=platforms"
 
   backupSyncPeriod:
   # `velero server` default: 1h
@@ -113,6 +117,8 @@ nodeAgent:
 #        - foo
 schedules:
   allnamespacebackup:
+    labels:
+      business-unit: platforms
     schedule: "0 0/3 * * *"
     template:
       ttl: "720h"


### PR DESCRIPTION
- schedule labels are passed as tags for volume backups
- s3 tagging config and required additional iam permissions added

relates to ministryofjustice/cloud-platform#6957