### PR TITLE
chore: 🤖 increase cpu limits for velero pod

### DIFF
--- a/templates/velero.yaml.tpl
+++ b/templates/velero.yaml.tpl
@@ -26,7 +26,7 @@ resources:
     cpu: 100m
     memory: 128Mi
   limits:
-    cpu: 500m
+    cpu: 2000m
     memory: 2048Mi
 
 initContainers:


### PR DESCRIPTION
Velero service is CPU throttling during backup intervals:

<img width="2480" height="1142" alt="image" src="https://github.com/user-attachments/assets/f47055e3-766f-4ef6-8a0d-1bd066fe3f8f" />
