### PR TITLE
chore: 🤖 disable backups for ingress-controllers

### DIFF
--- a/templates/velero.yaml.tpl
+++ b/templates/velero.yaml.tpl
@@ -123,6 +123,8 @@ schedules:
     schedule: "0 0/3 * * *"
     template:
       ttl: "720h"
+      excludedNamespaces:
+        - ingress-controllers
 
 configMaps:
   fs-restore-action-config:


### PR DESCRIPTION
## Purpose

@mikebell spotted that velero backups coincided with controller crashlooping. Doesn't appear to be any other issues around that time, and we have no use for ingress-controller backups, so excluding.

Consider doing similar for other non-persistent data reliant system namespaces.